### PR TITLE
Order list views by most recent first by default

### DIFF
--- a/matcher/dashboard/views/exports.py
+++ b/matcher/dashboard/views/exports.py
@@ -79,9 +79,12 @@ class ExportFileListView(View, DbMixin):
             .options(undefer(ExportFile.last_activity))
         )
 
-        ordering_key, ordering_direction = parse_ordering(
+        ordering = parse_ordering(
             request.args.get("ordering", None, str)
         )
+        ordering_key, ordering_direction = (ordering
+                                            if ordering != (None, None)
+                                            else ("date", "desc"))
         query = apply_ordering(
             {
                 "date": ExportFile.last_activity,

--- a/matcher/dashboard/views/imports.py
+++ b/matcher/dashboard/views/imports.py
@@ -47,9 +47,12 @@ class ImportFileListView(View, DbMixin):
 
         query = self.query(ImportFile).options(undefer(ImportFile.last_activity))
 
-        ordering_key, ordering_direction = parse_ordering(
+        ordering = parse_ordering(
             request.args.get("ordering", None, str)
         )
+        ordering_key, ordering_direction = (ordering
+                                            if ordering != (None, None)
+                                            else ("date", "desc"))
         query = apply_ordering(
             {
                 "date": ImportFile.last_activity,

--- a/matcher/dashboard/views/scraps.py
+++ b/matcher/dashboard/views/scraps.py
@@ -21,9 +21,12 @@ class ScrapListView(View, DbMixin):
 
         query = self.query(Scrap).options(joinedload(Scrap.platform))
 
-        ordering_key, ordering_direction = parse_ordering(
+        ordering = parse_ordering(
             request.args.get("ordering", None, str)
         )
+        ordering_key, ordering_direction = (ordering
+                                            if ordering != (None, None)
+                                            else ("date", "desc"))
         query = apply_ordering(
             {"date": Scrap.date, None: Scrap.id},
             query,


### PR DESCRIPTION
People are almost always interested in their recent activity, not by what happened eons ago. Sorting this way saves times and clicks and frustration.