### PR TITLE
Add download button to imports

### DIFF
--- a/matcher/dashboard/__init__.py
+++ b/matcher/dashboard/__init__.py
@@ -101,3 +101,7 @@ blueprint.add_url_rule(
     view_func=views.imports.ShowImportFileView.as_view("show_import_file"),
     methods=["GET", "POST"],
 )
+blueprint.add_url_rule(
+    "/imports/<int:id>/download",
+    view_func=views.imports.DownloadImportFileView.as_view("download_import_file"),
+)

--- a/matcher/dashboard/templates/imports/list.html
+++ b/matcher/dashboard/templates/imports/list.html
@@ -34,6 +34,9 @@
                   <td>{{ file.last_activity | relative_date }}</td>
                   <td>{{ file.filename }}</td>
                   <td class="td-actions">
+                    <a class="btn btn-sm btn-link" href="{{ url_for('.download_import_file', id=file.id) }}" rel="tooltip" title="Download file">
+                      <i class="material-icons">get_app</i>
+                    </a>
                     <a class="btn btn-sm btn-link" href="{{ url_for('.show_import_file', id=file.id) }}" rel="tooltip" title="View file">
                       <i class="material-icons">arrow_forward</i>
                     </a>

--- a/matcher/dashboard/templates/imports/show.html
+++ b/matcher/dashboard/templates/imports/show.html
@@ -38,7 +38,6 @@
           </dl>
         </div>
         <div class="d-flex justify-content-between">
-          {{ m.transition(file, 'schedule', url_for('.process_import_file', id=file.id)) }}
           {% if file.is_done %}
             <a class="btn btn-primary" href="{{ url_for('.download_import_file', id=file.id) }}">
               <i class="material-icons">get_app</i>

--- a/matcher/dashboard/templates/imports/show.html
+++ b/matcher/dashboard/templates/imports/show.html
@@ -37,6 +37,15 @@
 
           </dl>
         </div>
+        <div class="d-flex justify-content-between">
+          {{ m.transition(file, 'schedule', url_for('.process_import_file', id=file.id)) }}
+          {% if file.is_done %}
+            <a class="btn btn-primary" href="{{ url_for('.download_import_file', id=file.id) }}">
+              <i class="material-icons">get_app</i>
+              Download
+            </a>
+          {% endif %}
+        </div>
         <div class="card-footer">
           <a href="{{ url_for('.object_list', import_file=file.id) }}" class="btn btn-secondary">Show imported objects <i class="material-icons">arrow_forward</i></a>
         </div>

--- a/matcher/dashboard/templates/imports/show.html
+++ b/matcher/dashboard/templates/imports/show.html
@@ -37,16 +37,16 @@
 
           </dl>
         </div>
-        <div class="d-flex justify-content-between">
-          {% if file.is_done %}
-            <a class="btn btn-primary" href="{{ url_for('.download_import_file', id=file.id) }}">
-              <i class="material-icons">get_app</i>
-              Download
-            </a>
-          {% endif %}
-        </div>
         <div class="card-footer">
-          <a href="{{ url_for('.object_list', import_file=file.id) }}" class="btn btn-secondary">Show imported objects <i class="material-icons">arrow_forward</i></a>
+          <div class="button-container">
+            {% if file.is_done %}
+              <a class="btn btn-primary" href="{{ url_for('.download_import_file', id=file.id) }}">
+                <i class="material-icons">get_app</i>
+                Download
+              </a>
+            {% endif %}
+            <a href="{{ url_for('.object_list', import_file=file.id) }}" class="btn btn-secondary">Show imported objects <i class="material-icons">arrow_forward</i></a>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This adds a button to download import files in both the list and individual import page.

Known issue:
* [ ] This breaks the `/import/<id>` route