### PR TITLE
Fix issue with % char in secrets

### DIFF
--- a/matcher/migrations/env.py
+++ b/matcher/migrations/env.py
@@ -20,7 +20,8 @@ fileConfig(config.config_file_name)
 logger = logging.getLogger("alembic.env")
 
 config.set_main_option(
-    "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI")
+    "sqlalchemy.url",
+    current_app.config.get("SQLALCHEMY_DATABASE_URI").replace("%", "%%"),
 )
 target_metadata = Base.metadata
 


### PR DESCRIPTION
The README recommends a method to generate secrets that will lead to `%` characters in them. The current code is not able to cope with them. This is a fix for that.