### PR TITLE
Fix ugly use of pip as lib in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,6 @@ from os import path
 
 from setuptools import find_packages, setup
 
-# FIXME: This is an ugly workaround for pip 10
-try:  # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip < 10
-    from pip.req import parse_requirements
-
-
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
@@ -25,8 +18,10 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 def req(suite=None):
     suffix = '-' + suite if suite is not None else ''
-    return [str(r.req) for r in
-            parse_requirements('requirements{suffix}.txt'.format(suffix=suffix), session=False)]
+    req = ''
+    with open(f'requirements{suffix}.txt') as req_file:
+        req = req_file.readlines()
+    return req
 
 
 setup(


### PR DESCRIPTION
Change is quite trivial (and tested, it works), but I’d rather have @sandhose check if I didn’t forget anything.